### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 # Documentation
 
 The Cairo documentation consists of two parts: "Hello Cairo" and "How Cairo Works?".
-Both parts can be found in https://cairo-lang.org/docs/.
+Both parts can be found at https://cairo-lang.org/docs/.
 
 We recommend starting from [Setting up the environment](https://cairo-lang.org/docs/quickstart.html).
 


### PR DESCRIPTION
In the second sentence under "Documentation,"  for grammatical correctness: "Both parts can be found in https://cairo-lang.org/docs/." should be "Both parts can be found at https://cairo-lang.org/docs/."